### PR TITLE
feat: add linkStyle props to Bubble component

### DIFF
--- a/src/Bubble.tsx
+++ b/src/Bubble.tsx
@@ -143,6 +143,7 @@ export interface BubbleProps<TMessage extends IMessage> {
   containerStyle?: LeftRightStyle<ViewStyle>
   wrapperStyle?: LeftRightStyle<ViewStyle>
   textStyle?: LeftRightStyle<TextStyle>
+  linkStyle?: LeftRightStyle<TextStyle>
   bottomContainerStyle?: LeftRightStyle<ViewStyle>
   tickStyle?: StyleProp<TextStyle>
   containerToNextStyle?: LeftRightStyle<ViewStyle>
@@ -196,6 +197,7 @@ export default class Bubble<
     previousMessage: {},
     containerStyle: {},
     wrapperStyle: {},
+    linkStyle: {},
     bottomContainerStyle: {},
     tickStyle: {},
     usernameStyle: {},


### PR DESCRIPTION
Add `linkStyle` props to `Bubble` component that is then passed down to the `MessageText` component to display links with the given style without needing to add a `renderMessageText` function with the custom style.

Tested on react-native-web with `linkStyle={{ right: { color: "green" }}}` and `parsePatterns` styling `#{word}`
<img width="465" alt="Screenshot 2021-12-22 at 10 32 44" src="https://user-images.githubusercontent.com/9000214/147070393-d8a094f2-d726-4131-bf70-3baceabd46dd.png">
