### PR TITLE
fix: reset layout when renderAccessory updated

### DIFF
--- a/src/GiftedChat.tsx
+++ b/src/GiftedChat.tsx
@@ -468,6 +468,12 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     if (text !== prevProps.text) {
       this.setTextFromProp(text)
     }
+    if (
+      (prevProps.renderAccessory && !this.props.renderAccessory) ||
+      (!prevProps.renderAccessory && this.props.renderAccessory)
+    ) {
+      this.resetInputToolbar(false)
+    }
   }
 
   initLocale() {
@@ -747,8 +753,8 @@ class GiftedChat<TMessage extends IMessage = IMessage> extends React.Component<
     }
   }
 
-  resetInputToolbar() {
-    if (this.textInput) {
+  resetInputToolbar(clearInput: boolean = true) {
+    if (clearInput && this.textInput) {
       this.textInput.clear()
     }
     this.notifyInputTextReset()


### PR DESCRIPTION
When `renderAccessory` is updated to undefined, the layout doesn't reset and the size is kept as the accessory is still there (same in the other way around when adding a `renderAccessory`)

https://user-images.githubusercontent.com/9000214/154541518-3bbd11aa-0a4e-4431-93e9-7decc867cff8.mp4
